### PR TITLE
chore: set securityContext for initContainer

### DIFF
--- a/charts/daps-server/templates/deployment.yaml
+++ b/charts/daps-server/templates/deployment.yaml
@@ -31,6 +31,8 @@ spec:
       initContainers:
       - name: init-fill-pvc
         image: alpine
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
         command: 
         - "sh"
         - "-c"


### PR DESCRIPTION
As already for the main container the case - the initContainer should also receive the `securityContext` value.

https://github.com/eclipse-tractusx/daps-helm-chart/blob/5e25c56df1d66433f84217794fcc443a252e312a/charts/daps-server/templates/deployment.yaml#L98-L103

---
Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md))