### PR TITLE
fix: remove default azurefile storageClass

### DIFF
--- a/charts/daps-server/templates/persistentvolumeclaim.yaml
+++ b/charts/daps-server/templates/persistentvolumeclaim.yaml
@@ -4,11 +4,12 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ include "daps-server.fullname" . }}
 spec:
-  storageClassName: {{ .Values.persistence.storageClass | default "azurefile" }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
   accessModes:
     - {{ .Values.persistence.accessMode | default "ReadWriteOnce" }}
   resources:
     requests:
       storage: {{ .Values.persistence.storageSize }}
-
 {{- end }}

--- a/charts/daps-server/values.yaml
+++ b/charts/daps-server/values.yaml
@@ -87,7 +87,7 @@ ingress:
 persistence:
   # -- If `true` persistent volume will be used to store clients and users configuration
   enabled: true
-  # -- Storage class to claim a volume, defaults to azurefile.
+  # -- Storage class, defaults to none specified.
   storageClass: ""
   # -- Storage accessMode, defaults to ReadWriteOnce.
   accessMode: []


### PR DESCRIPTION
Do not enforce the `azurefile` as default persistence `storageClass`.

For enduser which do not use azure it is not a good practice to lock azure here - this should be set via values file.

---
Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md))