### PR TITLE
feat: use daps image for initContainer (no root)

### DIFF
--- a/charts/daps-server/templates/deployment.yaml
+++ b/charts/daps-server/templates/deployment.yaml
@@ -36,48 +36,45 @@ spec:
         - "-c"
         args:
         - |
-          ls /tmp/
-          # if [ ! -f /tmp/users.yml ]; then
+          mkdir -p /tmp/config /tmp/keys
+          # ls /tmp/
+          if [ ! -f /tmp/config/users.yml ]; then
             echo "File users.yml not found in pvc!. Creating empty file"
-            touch /tmp/users.yml
-          # fi
+            touch /tmp/config/users.yml
+          fi
           if [ -d /tmp/key.pem ]; then
             echo "Fix key is directory"
             rm -rf /tmp/key.pem
           fi
           if [ ! -f /tmp/key.pem ]; then
             echo "File key.pem not found in pvc!. Generating new key!"
-            apk add openssl
             openssl genrsa -out /tmp/key.pem 1024
           fi
-          if [ ! -f /tmp/clients.yml ]; then
+          if [ ! -f /tmp/config/clients.yml ]; then
             echo "File clients.yml not found in pvc! Creating a new one with default admin client"
             {{- if .Values.omejdn.createDefaultAdmin }}
-            cp /tmp2/clients.yml /tmp/clients.yml
+            cp /tmp2/clients.yml /tmp/config/clients.yml
             {{- else }}
-            touch /tmp/clients.yml
+            touch /tmp/config/clients.yml
             {{- end }}
           fi
-          if [ ! -f /tmp/omejdn.yml ]; then
+          # mounting as configmap is not an option as server expects this file writeable
+          if [ ! -f /tmp/config/omejdn.yml ]; then
             echo "File omejdn.yml not found in pvc! Creating a new one with default admin client"
             {{- if .Values.omejdn.createDefaultAdmin }}
-            cp /tmp2/omejdn.yml /tmp/omejdn.yml
+            cp /tmp2/omejdn.yml /tmp/config/omejdn.yml
             {{- else }}
-            touch /tmp/omejdn.yml
+            touch /tmp/config/omejdn.yml
             {{- end }}
           fi
-          if [ ! -f /tmp/scope_mapping.yml ]; then
+          if [ ! -f /tmp/config/scope_mapping.yml ]; then
             echo "File scope_mapping.yml not found in pvc! Creating a new one with default admin client"
             {{- if .Values.omejdn.createDefaultAdmin }}
-            cp /tmp2/scope_mapping.yml /tmp/scope_mapping.yml
+            cp /tmp2/scope_mapping.yml /tmp/config/scope_mapping.yml
             {{- else }}
-            touch /tmp/scope_mapping.yml
+            touch /tmp/config/scope_mapping.yml
             {{- end }}
           fi
-          if [ ! -d /tmp/keys ]; then
-            echo "keys directory not found in pvc! Creating empty dit"
-            mkdir /tmp/keys
-          fi      
         volumeMounts:
         - name: config
           mountPath: /tmp/

--- a/charts/daps-server/templates/deployment.yaml
+++ b/charts/daps-server/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
       - name: init-fill-pvc
-        image: alpine
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         command: 
         - "sh"
         - "-c"

--- a/charts/daps-server/templates/deployment.yaml
+++ b/charts/daps-server/templates/deployment.yaml
@@ -158,22 +158,6 @@ spec:
           - mountPath: {{ .Values.omejdn.serverKeyFolderPath }}/key.pem
             name: config
             subPath: key.pem
-          - mountPath: {{ .Values.omejdn.serverKeyFolderPath }}/config/users.yml
-            name: config
-            subPath: users.yml
-            readOnly: false
-          - mountPath: {{ .Values.omejdn.serverKeyFolderPath }}/config/clients.yml
-            name: config
-            subPath: clients.yml
-            readOnly: false
-          - mountPath: {{ .Values.omejdn.serverKeyFolderPath }}/config/omejdn.yml
-            name: config
-            subPath: omejdn.yml
-            readOnly: false
-          - mountPath: {{ .Values.omejdn.serverKeyFolderPath }}/config/scope_mapping.yml
-            name: config
-            subPath: scope_mapping.yml
-            readOnly: false
           - mountPath: {{ .Values.omejdn.serverKeyFolderPath }}/keys
             name: config
             subPath: keys

--- a/charts/daps-server/templates/deployment.yaml
+++ b/charts/daps-server/templates/deployment.yaml
@@ -147,6 +147,10 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
+          - mountPath: {{ .Values.omejdn.serverKeyFolderPath }}/config
+            name: config
+            subPath: config
+            readOnly: false
           - mountPath: {{ .Values.omejdn.serverKeyFolderPath }}/config/plugins.yml
             name: plugins-config
             subPath: plugins.yml


### PR DESCRIPTION
Instead of using `alpine` as `initContainer` also the image from the main application can be used.
This will not only allow to require less images to be pulled, also openssl is already present in the image.

This change will also simplify the init script and its mounts of the `config`-pvc.

**Background**
With this change also the `initContainer` will not run as root user.
All of this change will be required to run this deployment as non-root.

---
Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md))