### PR TITLE
chore: add missing labels to pvc and secret

### DIFF
--- a/charts/daps-server/templates/persistentvolumeclaim.yaml
+++ b/charts/daps-server/templates/persistentvolumeclaim.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "daps-server.fullname" . }}
+  labels:
+    {{- include "daps-server.labels" . | nindent 4 }}
 spec:
   storageClassName: {{ .Values.persistence.storageClass | default "azurefile" }}
   accessModes:

--- a/charts/daps-server/templates/secret.yml
+++ b/charts/daps-server/templates/secret.yml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "daps-server.applicationSecret.name" . }}
+  labels:
+    {{- include "daps-server.labels" . | nindent 4 }}
 type: Opaque
 stringData:
   ClientID: {{ .Values.daps.secret.clientId | default (randAlphaNum 16) }}


### PR DESCRIPTION
Adding missing labels for `PersistentVolumeClaim` and `Secret` kinds to daps-server chart.

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))