### PR TITLE
feat(daps-server): add networkPolicy

### DIFF
--- a/charts/daps-server/templates/networkpolicy.yaml
+++ b/charts/daps-server/templates/networkpolicy.yaml
@@ -1,0 +1,41 @@
+{{- if eq (.Values.networkPolicy.enabled | toString) "true"  }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "daps-server.fullname" . }}
+  labels:
+    {{- include "daps-server.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "daps-server.selectorLabels" . | nindent 6 }}
+  ingress:
+  {{- if .Values.networkPolicy.customFrom }}
+  - from:
+    {{- toYaml .Values.networkPolicy.customFrom | nindent 4 }}
+  {{- else }}
+  - from:
+    {{- if and .Values.networkPolicy.namespaceSelector.matchLabels .Values.networkPolicy.podSelector.matchLabels }}
+    - namespaceSelector:
+        matchLabels:
+          {{- toYaml .Values.networkPolicy.namespaceSelector.matchLabels | nindent 10 }}
+      podSelector:
+        matchLabels:
+          {{- toYaml .Values.networkPolicy.podSelector.matchLabels | nindent 10 }}
+    {{- else if .Values.networkPolicy.namespaceSelector.matchLabels }}
+    - namespaceSelector:
+        matchLabels:
+          {{- toYaml .Values.networkPolicy.namespaceSelector.matchLabels | nindent 10 }}
+    {{- else }}
+    - namespaceSelector: {}
+      {{- if .Values.networkPolicy.podSelector.matchLabels }}
+      podSelector:
+        matchLabels:
+          {{- toYaml .Values.networkPolicy.podSelector.matchLabels | nindent 10 }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+    ports:
+    - port: 4567
+      protocol: TCP
+{{- end }}

--- a/charts/daps-server/templates/networkpolicy.yaml
+++ b/charts/daps-server/templates/networkpolicy.yaml
@@ -36,6 +36,6 @@ spec:
     {{- end }}
   {{- end }}
     ports:
-    - port: 4567
+    - port: {{ .Values.service.targetPort }}
       protocol: TCP
 {{- end }}

--- a/charts/daps-server/values.yaml
+++ b/charts/daps-server/values.yaml
@@ -84,6 +84,20 @@ ingress:
       # -- Cert-manager issuer name
       issuer: "letsencrypt-prod"
 
+networkPolicy:
+  # -- If `true` network policy will be created to restrict access to DAPS
+  enabled: false
+  # -- NamespaceSelector configuration for network policy
+  namespaceSelector:
+    # -- Labels for namespaces to match with network policy
+    matchLabels: {}
+  # -- PodSelector configuration for network policy
+  podSelector:
+    # -- Labels for pods to match with network policy
+    matchLabels: {}
+  # -- Specify a custom from rule network policy
+  customFrom: []
+
 persistence:
   # -- If `true` persistent volume will be used to store clients and users configuration
   enabled: true


### PR DESCRIPTION
Adding a `networkPolicy` resource to the `daps-server` chart.

The policy can be customised with different values to fit everyones requirements:
- `networkPolicy.enabled ` - enable networkPolicy 
- `networkPolicy.namespaceSelector.matchLabels` - specify if only some namespaces should be allowed
- `networkPolicy.podSelector.matchLabels` - specify which labels should be allowed
- `networkPolicy.customFrom` - specify a custom from section (for more complex scenarios)

When the `networkPolicy` is enabled by default every pod from any namespace will be allowed.

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))