### PR TITLE
fix(daps-server): add targetPort to values file

### DIFF
--- a/charts/daps-server/templates/configmap.yml
+++ b/charts/daps-server/templates/configmap.yml
@@ -65,7 +65,7 @@ data:
     ---
     issuer: https://{{ .Values.ingress.host }}
     front_url: https://{{ .Values.ingress.host }}
-    bind_to: 0.0.0.0:4567
+    bind_to: 0.0.0.0:{{ .Values.service.targetPort }}
     environment: development
     openid: false
     default_audience: idsc:IDS_CONNECTORS_ALL

--- a/charts/daps-server/templates/deployment.yaml
+++ b/charts/daps-server/templates/deployment.yaml
@@ -128,7 +128,7 @@ spec:
           {{- end}}
           ports:
             - name: http
-              containerPort: 4567
+              containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
           #livenessProbe:
           #  httpGet:

--- a/charts/daps-server/values.yaml
+++ b/charts/daps-server/values.yaml
@@ -60,6 +60,8 @@ service:
   type: ClusterIP
   # -- Service port
   port: 4567
+  # -- Service target port
+  targetPort: 4567
 
 ingress:
   # -- If set to `true`, DAPS will be exposed with ingress controller at http(s)://(ingress.host)/(ingress.pathPrefix)


### PR DESCRIPTION
The `service.targetPort` value is missing in the `values.yaml`-file but already used:

https://github.com/eclipse-tractusx/daps-helm-chart/blob/7c512f4e7177c8290b784921e4ea3ca88e75fb59/charts/daps-server/templates/service.yaml#L11

Therefore I've added this value and templated it to every resource where it is referenced.

Maybe the `service.targetPort` should be changed to any other value key.
It might be better to name it without the service prefix - e.g. `omejdn.port` or `app.port`.
Any suggestions?

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))