### PR TITLE
fix(helm): use openid-configuration path for Helm test

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,4 +6,4 @@ The following people have contributed to this repository:
 * Dmitrii Vasiunin, doubleSlash Net-Business GmbH, https://github.com/dvasunin
 * Amol Dashwant, T-Systems International GmbH, https://github.com/amoldashwant
 * Fedor Nazarov, doubleSlash Net-Business GmbH, https://github.com/Wulghash 
-
+* Marco Lecheler, Mercedes-Benz Tech Innovation GmbH, https://github.com/fty4

--- a/charts/daps-server/Chart.yaml
+++ b/charts/daps-server/Chart.yaml
@@ -38,7 +38,7 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.9
+version: 1.7.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/daps-server/templates/tests/test-connection.yaml
+++ b/charts/daps-server/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "daps-server.fullname" . }}:{{ .Values.service.port }}']
+      args: ['{{ include "daps-server.fullname" . }}:{{ .Values.service.port }}/.well-known/openid-configuration']
   restartPolicy: Never


### PR DESCRIPTION
When testing against the root path the server will return a `404` status code which results in an unsuccessful test:

```
$ helm test lab 
NAME: lab
LAST DEPLOYED: Fri Jun  2 09:13:17 2023
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE:     lab-dapsserver-test-connection
Last Started:   Fri Jun  2 09:16:46 2023
Last Completed: Fri Jun  2 09:16:51 2023
Phase:          Failed
Error: 1 error occurred:
        * pod lab-dapsserver-test-connection failed
```

When changing the endpoint to `/.well-known/openid-configuration` a HTTP/1.1 `200` OK will be returned:

```
$ helm test lab                                  
NAME: lab
LAST DEPLOYED: Fri Jun  2 09:43:00 2023
NAMESPACE: default
STATUS: deployed
REVISION: 3
TEST SUITE:     lab-dapsserver-test-connection
Last Started:   Fri Jun  2 09:43:03 2023
Last Completed: Fri Jun  2 09:43:08 2023
Phase:          Succeeded
TEST SUITE:     lab-server-test
Last Started:   Fri Jun  2 09:43:08 2023
Last Completed: Fri Jun  2 09:43:11 2023
Phase:          Succeeded
```

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))