### PR TITLE
chore(helm): set image.repository as required value

### DIFF
--- a/charts/daps-server/templates/deployment.yaml
+++ b/charts/daps-server/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       initContainers:
       - name: init-fill-pvc
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.image.repository | required ".Values.image.repository is required" }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
         command:
@@ -99,7 +99,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository | required ".Values.image.repository is required" }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
           - name: OMEJDN_PLUGINS


### PR DESCRIPTION
If the `image.repository` value is not given the deployment will fail.
Therefore the field should be a required value.

 Otherwise following errors will be presented:

> Failed to apply default image tag ":1.7.1": couldn't parse image reference ":1.7.1": invalid reference format 

> Error: InvalidImageName

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))