### PR TITLE
fix(helm): change http protocol for omejdn.yml if TLS enabled

### DIFF
--- a/charts/daps-server/Chart.yaml
+++ b/charts/daps-server/Chart.yaml
@@ -38,7 +38,7 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.10
+version: 1.7.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/daps-server/templates/configmap.yml
+++ b/charts/daps-server/templates/configmap.yml
@@ -61,15 +61,15 @@ data:
 
   omejdn.yml: |-
     ---
-    issuer: https://{{ .Values.ingress.host }}
-    front_url: https://{{ .Values.ingress.host }}
+    issuer: http{{- if .Values.ingress.tls.enabled -}}s{{- end -}}://{{ .Values.ingress.host }}
+    front_url: http{{- if .Values.ingress.tls.enabled -}}s{{- end -}}://{{ .Values.ingress.host }}
     bind_to: 0.0.0.0:{{ .Values.service.targetPort }}
     environment: development
     openid: false
     default_audience: idsc:IDS_CONNECTORS_ALL
     accept_audience:
-    - https://{{ .Values.ingress.host }}{{ .Values.ingress.rootPath }}
-    - https://{{ .Values.ingress.host }}{{ .Values.ingress.rootPath }}token
+    - http{{- if .Values.ingress.tls.enabled -}}s{{- end -}}://{{ .Values.ingress.host }}{{ .Values.ingress.rootPath }}
+    - http{{- if .Values.ingress.tls.enabled -}}s{{- end -}}://{{ .Values.ingress.host }}{{ .Values.ingress.rootPath }}token
     - idsc:IDS_CONNECTORS_ALL
     access_token:
       expiration: 3600

--- a/charts/daps-server/templates/configmap.yml
+++ b/charts/daps-server/templates/configmap.yml
@@ -61,15 +61,15 @@ data:
 
   omejdn.yml: |-
     ---
-    issuer: http{{- if .Values.ingress.tls.enabled -}}s{{- end -}}://{{ .Values.ingress.host }}
-    front_url: http{{- if .Values.ingress.tls.enabled -}}s{{- end -}}://{{ .Values.ingress.host }}
+    issuer: http{{- if .Values.ingress.tls.enabled -}}s{{- end -}}://{{ tpl .Values.ingress.host . }}
+    front_url: http{{- if .Values.ingress.tls.enabled -}}s{{- end -}}://{{ tpl .Values.ingress.host . }}
     bind_to: 0.0.0.0:{{ .Values.service.targetPort }}
     environment: development
     openid: false
     default_audience: idsc:IDS_CONNECTORS_ALL
     accept_audience:
-    - http{{- if .Values.ingress.tls.enabled -}}s{{- end -}}://{{ .Values.ingress.host }}{{ .Values.ingress.rootPath }}
-    - http{{- if .Values.ingress.tls.enabled -}}s{{- end -}}://{{ .Values.ingress.host }}{{ .Values.ingress.rootPath }}token
+    - http{{- if .Values.ingress.tls.enabled -}}s{{- end -}}://{{ tpl .Values.ingress.host . }}{{ .Values.ingress.rootPath }}
+    - http{{- if .Values.ingress.tls.enabled -}}s{{- end -}}://{{ tpl .Values.ingress.host . }}{{ .Values.ingress.rootPath }}token
     - idsc:IDS_CONNECTORS_ALL
     access_token:
       expiration: 3600

--- a/charts/daps-server/values.yaml
+++ b/charts/daps-server/values.yaml
@@ -92,7 +92,7 @@ ingress:
   #  kubernetes.io/ingress.class: nginx
   #  kubernetes.io/tls-acme: "true"
   # -- Ingress host name
-  host: daps-beta.int.demo.catena-x.net
+  host: "{{ .Release.Name }}-daps-server"
   # -- Path prefix to be added to DAPS URI. Regex can be used
   pathPrefix: "/"
   # -- Root prefix without regex rules that used to configure daps host name in configuration


### PR DESCRIPTION
Currently the configmap is hardcoding https protocol for the `issuer`, `front_url` and `accept_audience`.

This will not allow to use the daps-server without TLS.
For local dev environments this should be supported.

This PR also changes that that the `ingress.host` value can be templated.
Due this change the `.Release.Name` can be templated inside the URL (also useful for local dev envs).

Also the default `ingress.host` value should not point to a specific endpoint (currently `daps-beta.int.demo.catena-x.net`).
A default value should be the service name - other values should be provided by the specifiv `values-*.yaml` file.

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))