### PR TITLE
chore(helm): remove parent daps key

### DIFF
--- a/charts/daps-server/templates/configmap.yml
+++ b/charts/daps-server/templates/configmap.yml
@@ -83,9 +83,9 @@ data:
   {{- if .Values.omejdn.createDefaultAdmin }}
   clients.yml: |-
     ---
-    - client_id: {{ .Values.daps.secret.clientId }}
+    - client_id: {{ .Values.secret.clientId }}
       name: omejdn admin ui
-      client_secret: {{ .Values.daps.secret.clientSecret }}
+      client_secret: {{ .Values.secret.clientSecret }}
       token_endpoint_auth_method: client_secret_post
       attributes:
       - key: omejdn

--- a/charts/daps-server/templates/secret.yml
+++ b/charts/daps-server/templates/secret.yml
@@ -6,5 +6,5 @@ metadata:
     {{- include "daps-server.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  ClientID: {{ .Values.daps.secret.clientId | default (randAlphaNum 16) }}
-  ClientSecret: {{ .Values.daps.secret.clientSecret | default (randAlphaNum 16) }}
+  ClientID: {{ .Values.secret.clientId | default (randAlphaNum 16) }}
+  ClientSecret: {{ .Values.secret.clientSecret | default (randAlphaNum 16) }}

--- a/charts/daps-server/values-beta.yaml
+++ b/charts/daps-server/values-beta.yaml
@@ -41,7 +41,6 @@ ingress:
       # -- Cert-manager issuer name
       issuer: "letsencrypt-prod"
 
-daps:
-  secret:
-    clientId: "<path:essential-services/data/daps-beta#clientId>"
-    clientSecret: "<path:essential-services/data/daps-beta#clientSecret>"
+secret:
+  clientId: "<path:essential-services/data/daps-beta#clientId>"
+  clientSecret: "<path:essential-services/data/daps-beta#clientSecret>"

--- a/charts/daps-server/values-dev.yaml
+++ b/charts/daps-server/values-dev.yaml
@@ -41,7 +41,6 @@ ingress:
       # -- Cert-manager issuer name
       issuer: "letsencrypt-prod"
 
-daps:
-  secret:
-    clientId: "<path:essential-services/data/daps-dev#clientId>"
-    clientSecret: "<path:essential-services/data/daps-dev#clientSecret>"
+secret:
+  clientId: "<path:essential-services/data/daps-dev#clientId>"
+  clientSecret: "<path:essential-services/data/daps-dev#clientSecret>"

--- a/charts/daps-server/values-int.yaml
+++ b/charts/daps-server/values-int.yaml
@@ -41,10 +41,9 @@ ingress:
       # -- Cert-manager issuer name
       issuer: "letsencrypt-prod"
 
-daps:
-  secret:
-    clientId: "<path:essential-services/data/daps#clientId>"
-    clientSecret: "<path:essential-services/data/daps#clientSecret>"
+secret:
+  clientId: "<path:essential-services/data/daps#clientId>"
+  clientSecret: "<path:essential-services/data/daps#clientSecret>"
     
     
 resources:

--- a/charts/daps-server/values-preprod.yaml
+++ b/charts/daps-server/values-preprod.yaml
@@ -41,7 +41,6 @@ ingress:
       # -- Cert-manager issuer name
       issuer: "letsencrypt-prod"
 
-daps:
-  secret:
-    clientId: "<path:essential-services/data/daps-preprod#clientId>"
-    clientSecret: "<path:essential-services/data/daps-preprod#clientSecret>"
+secret:
+  clientId: "<path:essential-services/data/daps-preprod#clientId>"
+  clientSecret: "<path:essential-services/data/daps-preprod#clientSecret>"

--- a/charts/daps-server/values-test.yaml
+++ b/charts/daps-server/values-test.yaml
@@ -41,7 +41,6 @@ ingress:
       # -- Cert-manager issuer name
       issuer: "letsencrypt-prod"
 
-daps:
-  secret:
-    clientId: "<path:essential-services/data/daps-beta#clientId>"
-    clientSecret: "<path:essential-services/data/daps-beta#clientSecret>"
+secret:
+  clientId: "<path:essential-services/data/daps-beta#clientId>"
+  clientSecret: "<path:essential-services/data/daps-beta#clientSecret>"

--- a/charts/daps-server/values.yaml
+++ b/charts/daps-server/values.yaml
@@ -163,7 +163,6 @@ tolerations: []
 # -- Pod affinity configuration
 affinity: {}
 
-daps:
-  secret:
-    clientId: ""
-    clientSecret: ""
+secret:
+  clientId: ""
+  clientSecret: ""


### PR DESCRIPTION
It is not required to use the daps parent key for the secret elements.
Daps is already know because of the chart name.

If the daps-server is used as dependency then there would be a duplicate daps key:

```yaml
daps: # dependency chart (alias)
  daps: # this will be removed with this PR
    secret:
      clientId: foo
      clientSecret: bar
```

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))