### PR TITLE
chore: update pod security context configuration

### DIFF
--- a/charts/daps-server/Chart.yaml
+++ b/charts/daps-server/Chart.yaml
@@ -38,7 +38,7 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.0
+version: 1.8.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/daps-server/templates/deployment.yaml
+++ b/charts/daps-server/templates/deployment.yaml
@@ -26,14 +26,18 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "daps-server.serviceAccountName" . }}
+      {{- if .Values.podSecurityContext }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
       initContainers:
       - name: init-fill-pvc
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        {{- if .Values.securityContext }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end }}
         command:
         - "sh"
         - "-c"
@@ -97,8 +101,10 @@ spec:
           readOnly: false
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.securityContext }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:

--- a/charts/daps-server/values.yaml
+++ b/charts/daps-server/values.yaml
@@ -63,8 +63,12 @@ serviceAccount:
 podAnnotations: {}
 
 # -- Pod security context configuration
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
 
 # -- Pod security context configuration
 securityContext:
@@ -73,8 +77,6 @@ securityContext:
   #   drop:
   #   - ALL
   # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  runAsUser: 1000
 
 service:
   # -- Service type


### PR DESCRIPTION
The pod security context in the values.yaml file has been updated to include the following changes:
- Added `runAsNonRoot: true` to ensure the pod runs as a non-root user.
- Added `runAsUser: 1000` to specify the user ID for the pod.
- Added `runAsGroup: 1000` to specify the group ID for the pod.
- Added `fsGroup: 1000` to specify the file system group ID for the pod.
  This ensures the pvc can be attached properly.

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))